### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
+    - stable
     - beta
     - nightly
 sudo: false


### PR DESCRIPTION
Now that 1.6 is stable, we can have travis build with this level

(previously we couldn't, because `read_exact` was only added in 1.6)