### PR TITLE
Do not panic on unsupported compression type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,11 @@ pub enum Error {
     /// There was an error during IO
     Io(io::Error),
     BadEncoding(string::FromUtf8Error),
+    /// Currently, only zlib is implemented.
+    UnsupportedCompressionFormat{
+        /// Compression type byte from the format.
+        compression_type: u8
+    },
     UnexpectedEOF,
 
     /// An unexpected tag was found while NBT Parsing
@@ -45,6 +50,7 @@ impl error::Error for Error {
             &Error::BadEncoding(..) => "Bad Encoding",
             &Error::UnexpectedEOF => "Unexpected EOF",
             &Error::UnexpectedTag(..) => "Unexpected Tag",
+            &Error::UnsupportedCompressionFormat{ compression_type: _ } => "Unsupported Compression",
         }
     }
 }

--- a/src/region.rs
+++ b/src/region.rs
@@ -116,7 +116,7 @@ impl<R> RegionFile<R> where R: Read + Seek
         let compression_type = try!(self.cursor.read_u8());
 
         if compression_type != 2 {
-            panic!("Compression types other than zlib are not supported right now");
+            return Err(nbt_error::Error::UnsupportedCompressionFormat{compression_type});
         }
 
         let compressed_data = {


### PR DESCRIPTION
Heya folks, it's me again.

An unsupported compression type can legitimately happen when we catch a region in the middle of a server updating it. This error can be nicely handled by simply retrying the read, but the panic disallows this.

Instead of panicking, this PR simply introduces a new error type and returns it when we encounter such a case.